### PR TITLE
Check for failures in behat html output

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -21,3 +21,14 @@ default:
       api_driver: 'drush'
       drush:
         alias: 'local'
+    emuse\BehatHTMLFormatter\BehatHTMLFormatterExtension:
+      name: html
+      renderer: Twig,Behat2
+      file_name: index
+      print_args: true
+      print_outp: true
+      loop_break: true
+  formatters:
+    pretty: true
+    html:
+      output_path: 'behat_results'

--- a/bin/script.sh
+++ b/bin/script.sh
@@ -2,25 +2,12 @@
 
 # script
 export PATH="$HOME/.composer/vendor/bin:$PATH"
-export REPOSITORY_NAME=$(find $TRAVIS_BUILD_URL -mindepth 1 -maxdepth 1 -name "*.info" -type f -printf '%f\n' | cut -f1 -d".")
-cd $HOME/stanford_travisci_scripts
 
-# collect the list of feature files to run
-BEHAT_TESTS=$(find features -name "*.feature" -type f -printf '%f\n')
-echo "$BEHAT_TESTS"
-FAILURES_COUNT=0
+# run through all tests in features directory
+timeout 3m bin/behat -p default -s dev features
 
-# run through each test, one at a time
-for TEST in ${BEHAT_TESTS[@]}; do
-  timeout 3m bin/behat -p default -s dev -f pretty features/$REPOSITORY_NAME/$TEST
-  # TEST_RESULT=$(timeout 3m bin/behat -p default -s dev -f pretty features/$REPOSITORY_NAME/$TEST)
-  # if [[ $TEST_RESULT == *"Failed"* ]] || [[ $TEST_RESULT == *"Terminated"* ]]; then
-    # ((FAILURES_COUNT++))
-    # drush @local si -y stanford
-    # timeout 3m bin/behat -p default -s dev -f pretty features/$REPOSITORY_NAME/$TEST
-  # fi
-done
-
+# grap the number of failures from behat's html output summary report
+FAILURES_COUNT=$(cat behat_results/index.html | grep 'scenarios failed of' | sed -r 's/^([^.]+).*$/\1/; s/^[^0-9]*([0-9]+).*$/\1/')
 echo "Number of failed tests: $FAILURES_COUNT"
 
 # fail script.sh if behat returned at least one failure

--- a/bin/script.sh
+++ b/bin/script.sh
@@ -4,7 +4,7 @@
 export PATH="$HOME/.composer/vendor/bin:$PATH"
 
 # run through all tests in features directory
-timeout 3m bin/behat -p default -s dev features
+bin/behat -p default -s dev features
 
 # grap the number of failures from behat's html output summary report
 FAILURES_COUNT=$(cat behat_results/index.html | grep 'scenarios failed of' | sed -r 's/^([^.]+).*$/\1/; s/^[^0-9]*([0-9]+).*$/\1/')


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removing code that used to run one behat at a time and re-install the site after a test's first failure.  This was a bad idea for several reasons.  It took a long time.  We can reasonably expect that all tests for a particular module should pass without requiring a site re-install.  And I was running tests once to save as a variable and a second time to output in full color, which took extra time and likely caused problems (like paths turning into path-0).

# Needed By (Date)
- Today would give my work week a nice sense of closure.

# Urgency
- We would like to have Travis working on at least one or two modules under development this week and next for HSDO's sprint.

# Steps to Test
- After merge, be sure the stanford_landing_page variable SCRIPTS_BRANCH is empty, or at least no longer set to sheat.  Then rebuild the test run on travis-ci.org.

# Affected Projects or Products
- stanford_landing_page

# Associated Issues and/or People
- @kbrownell