### PR TITLE
Test deployer

### DIFF
--- a/bin/before_install.sh
+++ b/bin/before_install.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 # before_install
-export REPOSITORY_NAME=$(basename $TRAVIS_BUILD_DIR)⏎
-echo "$REPOSITORY_NAME"
 cd $HOME/stanford_travisci_scripts
 composer install
 composer global require drush/drush:7.1.0

--- a/bin/before_install.sh
+++ b/bin/before_install.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # before_install
+export REPOSITORY_NAME=$(basename $TRAVIS_BUILD_DIR)⏎
+echo "$REPOSITORY_NAME"
 cd $HOME/stanford_travisci_scripts
 composer install
 composer global require drush/drush:7.1.0

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -60,8 +60,7 @@ fi
 
 # output which tests have been copied over
 echo "features ready for test run"
-TESTS_READY_TO_RUN=$(basename `find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature"`)
-echo "$TESTS_READY_TO_RUN"
+find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature"
 
 # start xvfb virtual display
 export DISPLAY=:99.0

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -39,11 +39,11 @@ function copy_module_tests {
 
 # loop through and copy specific tests called for by ONLY_TEST variable
 function copy_single_test {
+  mkdir $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
   TESTS=(`echo ${ONLY_TEST}`)
   for TEST in ${TESTS[@]}; do
     TEST_PATH=$(find $HOME/linky_clicky -type f -name "$TEST.feature")
-    echo $TEST_PATH
-    cp $TEST_PATH $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME/$TEST.feature
+    cp $TEST_PATH $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME/$TEST.feature $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME/.
   done
 }
 
@@ -59,6 +59,7 @@ else
 fi
 
 # output which tests have been copied over
+echo "features ready for test run"
 find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type d -name "*.feature"
 
 # start xvfb virtual display

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source includes/script_functions.inc
+
 # before_script
 export PATH="$HOME/.composer/vendor/bin:$PATH"
 export REPOSITORY_NAME=$(basename $TRAVIS_BUILD_DIR)
@@ -25,8 +27,10 @@ function copy_product_tests {
     ["jumpstart-lab"]="jsl"
   )
   ACRONYM="${PRODUCTS_LIST[$PRODUCT_NAME]}"
-  echo "cp -r $HOME/linky_clicky/products/$ACRONYM/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME"
-  cp -r $HOME/linky_clicky/products/$ACRONYM/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
+  if [ ! -z "$ACRONYM" ]; then
+    echo "cp -r $HOME/linky_clicky/products/$ACRONYM/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME"
+    cp -r $HOME/linky_clicky/products/$ACRONYM/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
+  fi
 }
 
 function copy_uat_tests {

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source includes/script_functions.inc
+source $HOME/stanford_travisci_scripts/bin/includes/script_functions.inc
 
 # before_script
 export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -60,7 +60,8 @@ fi
 
 # output which tests have been copied over
 echo "features ready for test run"
-basename `find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature"`
+TESTS_READY_TO_RUN=$(basename `find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature"`)
+echo "$TESTS_READY_TO_RUN"
 
 # start xvfb virtual display
 export DISPLAY=:99.0

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -60,7 +60,7 @@ fi
 
 # output which tests have been copied over
 echo "features ready for test run"
-echo $(find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type d -name "*.feature")
+echo $(find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature")
 
 # start xvfb virtual display
 export DISPLAY=:99.0

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -2,7 +2,7 @@
 
 # before_script
 export PATH="$HOME/.composer/vendor/bin:$PATH"
-export REPOSITORY_NAME=$(find $TRAVIS_BUILD_URL -mindepth 1 -maxdepth 1 -name "*.info" -type f -printf '%f\n' | cut -f1 -d".")
+export REPOSITORY_NAME=$(basename $TRAVIS_BUILD_DIR)
 # download linky_clicky and copy over related tests and required files
 if [ ! -z "$CLICKY_BRANCH" ]; then CLICKY_BRANCH="-b $CLICKY_BRANCH"; fi
 git clone --depth 1 $CLICKY_BRANCH https://github.com/SU-SWS/linky_clicky.git $HOME/linky_clicky
@@ -22,6 +22,9 @@ if [ "$REPOSITORY_NAME" == "stanford-jumpstart-deployer" ]; then
   echo "Suffix: $SUFFIX"
   echo "cp -r $HOME/linky_clicky/products/$SUFFIX/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME"
   cp -r $HOME/linky_clicky/products/$SUFFIX/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
+# copy over self-service site testes
+elseif [ "$REPOSITORY_NAME" == "Stanford-Drupal-Profile" ]; then
+  
 fi
 
 # copy over feature tests

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -43,7 +43,7 @@ function copy_single_test {
   for TEST in ${TESTS[@]}; do
     TEST_PATH=$(find $HOME/linky_clicky -type f -name "$TEST.feature")
     echo $TEST_PATH
-    cp $TEST_PATH $HOME/stanford_travisci_scripts/features/$TEST.feature
+    cp $TEST_PATH $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME/$TEST.feature
   done
 }
 
@@ -57,6 +57,9 @@ elif [ "$REPOSITORY_NAME" == "Stanford-Drupal-Profile" ]; then
 else
   copy_module_tests
 fi
+
+# output which tests have been copied over
+find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type d -name "*.feature"
 
 # start xvfb virtual display
 export DISPLAY=:99.0

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -14,6 +14,7 @@ ls $HOME/stanford_travisci_scripts/features
 if [ "$REPOSITORY_NAME" == "stanford-jumpstart-deployer" ]; then
   declare -A PRODUCTS_LIST=(
     ["jumpstart-academic"]="jsa"
+    ["jumpstart-engineering"]="jse"
     ["jumpstart-plus"]="jsplus"
     ["jumpstart"]="jsv"
     ["jumpstart-lab"]="jsl"

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -23,8 +23,8 @@ if [ "$REPOSITORY_NAME" == "stanford-jumpstart-deployer" ]; then
   echo "cp -r $HOME/linky_clicky/products/$SUFFIX/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME"
   cp -r $HOME/linky_clicky/products/$SUFFIX/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
 # copy over self-service site testes
-elseif [ "$REPOSITORY_NAME" == "Stanford-Drupal-Profile" ]; then
-  
+elif [ "$REPOSITORY_NAME" == "Stanford-Drupal-Profile" ]; then
+  cp -r $HOME/linky_clicky/sites/uat/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
 fi
 
 # copy over feature tests

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -20,7 +20,6 @@ if [ "$REPOSITORY_NAME" == "stanford-jumpstart-deployer" ]; then
     ["jumpstart-lab"]="jsl"
   )
   SUFFIX="${PRODUCTS_LIST[$PRODUCT_NAME]}"
-  echo "Suffix: $SUFFIX"
   echo "cp -r $HOME/linky_clicky/products/$SUFFIX/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME"
   cp -r $HOME/linky_clicky/products/$SUFFIX/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
 # copy over self-service site testes

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -60,7 +60,7 @@ fi
 
 # output which tests have been copied over
 echo "features ready for test run"
-echo $(find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature")
+basename `find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature"`
 
 # start xvfb virtual display
 export DISPLAY=:99.0

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -43,7 +43,7 @@ function copy_single_test {
   TESTS=(`echo ${ONLY_TEST}`)
   for TEST in ${TESTS[@]}; do
     TEST_PATH=$(find $HOME/linky_clicky -type f -name "$TEST.feature")
-    cp $TEST_PATH $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME/$TEST.feature $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME/.
+    cp $TEST_PATH $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME/$TEST.feature
   done
 }
 
@@ -60,7 +60,7 @@ fi
 
 # output which tests have been copied over
 echo "features ready for test run"
-find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type d -name "*.feature"
+echo $(find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type d -name "*.feature")
 
 # start xvfb virtual display
 export DISPLAY=:99.0

--- a/bin/includes/install_functions.inc
+++ b/bin/includes/install_functions.inc
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+function install_from_deployer {
+  # clone deployer and echo which branch will be cloned and used for the site build
+  if [ ! -z "$DEPLOYER_BRANCH" ]; then DEPLOYER_BRANCH="-b $DEPLOYER_BRANCH"; fi
+  echo "git clone --depth 1 $DEPLOYER_BRANCH https://github.com/SU-SWS/stanford-jumpstart-deployer.git $HOME/stanford-jumpstart-deployer"
+  git clone --depth 1 $DEPLOYER_BRANCH https://github.com/SU-SWS/stanford-jumpstart-deployer.git $HOME/stanford-jumpstart-deployer
+
+  # change git clones to https so they can be downloaded with access tokens
+  grep -rl 'git@github.com:' $HOME/stanford-jumpstart-deployer | xargs sed -i 's|git@github.com:|https://github.com/|'
+
+  # build site based on specified product name
+  drush make -y --force-complete $HOME/stanford-jumpstart-deployer/production/product/$PRODUCT_NAME/$PRODUCT_NAME.make $HOME/html
+
+  # find profile name by looking for "jumpstart" in profiles directory
+  export PROFILE_NAME=$(find $HOME/html/profiles -name "*jumpstart*" -type d -printf '%f\n')
+
+  # install site with product profile
+  drush @local si -y $PROFILE_NAME --db-url=mysql://root@localhost/drupal --account-name=admin --account-pass=admin
+}
+
+function install_from_drupal_profile {
+  # clone Drupal-Profile and echo which branch will be cloned and used for the site build
+  if [ ! -z "$DRUPAL_PROFILE_BRANCH" ]; then DRUPAL_PROFILE_BRANCH="-b $DRUPAL_PROFILE_BRANCH"; fi
+  echo "git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile"
+  git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile
+
+  # change git clones to https so they can be downloaded with access tokens
+  grep -rl 'git@github.com:' $HOME/Stanford-Drupal-Profile | xargs sed -i 's|git@github.com:|https://github.com/|'
+
+  # build self-service site
+  drush make -y --force-complete $HOME/Stanford-Drupal-Profile/make/dept.make $HOME/html
+
+  # install site with stanford, ie. self-service, profile
+  drush @local si -y stanford --db-url=mysql://root@localhost/drupal --account-name=admin --account-pass=admin
+}
+
+function update_test_branch {
+  # download pull request origination branch when testing profiles
+  if [ "$REPOSITORY_NAME" == "Stanford-Drupal-Profile" ]; then
+    DRUPAL_PROFILE_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
+  elif [ "$REPOSITORY_NAME" == "stanford-jumpstart-deployer" ]; then
+    DEPLOYER_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
+  fi
+}

--- a/bin/includes/install_functions.inc
+++ b/bin/includes/install_functions.inc
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# functions used by install.sh to determine which make files should be used to build a site
 function install_from_deployer {
   # clone deployer and echo which branch will be cloned and used for the site build
   if [ ! -z "$DEPLOYER_BRANCH" ]; then DEPLOYER_BRANCH="-b $DEPLOYER_BRANCH"; fi

--- a/bin/includes/script_functions.inc
+++ b/bin/includes/script_functions.inc
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# functions used by before_script.sh to determine which tests should be run
 # copy over production product tests
 function copy_product_tests {
   declare -A PRODUCTS_LIST=(

--- a/bin/includes/script_functions.inc
+++ b/bin/includes/script_functions.inc
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# copy over production product tests
+function copy_product_tests {
+  declare -A PRODUCTS_LIST=(
+    ["jumpstart-academic"]="jsa"
+    ["jumpstart-engineering"]="jse"
+    ["jumpstart-plus"]="jsplus"
+    ["jumpstart"]="jsv"
+    ["jumpstart-lab"]="jsl"
+  )
+  ACRONYM="${PRODUCTS_LIST[$PRODUCT_NAME]}"
+  if [ ! -z "$ACRONYM" ]; then
+    echo "cp -r $HOME/linky_clicky/products/$ACRONYM/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME"
+    cp -r $HOME/linky_clicky/products/$ACRONYM/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
+  fi
+}
+
+function copy_uat_tests {
+  cp -r $HOME/linky_clicky/sites/uat/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
+}
+
+function copy_module_tests {
+  cp -r $HOME/linky_clicky/includes/features/SU-SWS/$REPOSITORY_NAME $HOME/stanford_travisci_scripts/features/.
+}
+
+# loop through and copy specific tests called for by ONLY_TEST variable
+function copy_single_test {
+  mkdir $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
+  TESTS=(`echo ${ONLY_TEST}`)
+  for TEST in ${TESTS[@]}; do
+    TEST_PATH=$(find $HOME/linky_clicky -type f -name "$TEST.feature")
+    cp $TEST_PATH $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME/$TEST.feature
+  done
+}

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -3,7 +3,7 @@
 # install
 export PATH="$HOME/.composer/vendor/bin:$PATH"
 export REPOSITORY_NAME=$(basename $TRAVIS_BUILD_DIR)
-echo $REPOSITORY_NAME
+echo "$REPOSITORY_NAME"
 sed "s|ACCESS_TOKEN|$ACCESS_TOKEN|" $HOME/stanford_travisci_scripts/.netrc > $HOME/.netrc
 
 # save drush alias and update .htaccess file to allow rewriting

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source includes/install_functions.inc
+source $HOME/stanford_travisci_scripts/bin/includes/install_functions.inc
 
 # install
 export PATH="$HOME/.composer/vendor/bin:$PATH"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -17,6 +17,7 @@ if [ -z "$PRODUCT_NAME" ]; then
     DRUPAL_PROFILE_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
   fi
   if [ ! -z "$DRUPAL_PROFILE_BRANCH" ]; then DRUPAL_PROFILE_BRANCH="-b $DRUPAL_PROFILE_BRANCH"; fi
+  echo "git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile"
   git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile
   grep -rl 'git@github.com:' $HOME/Stanford-Drupal-Profile | xargs sed -i 's|git@github.com:|https://github.com/|'
   drush make -y --force-complete $HOME/Stanford-Drupal-Profile/make/dept.make $HOME/html
@@ -26,6 +27,7 @@ else
     DEPLOYER_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
   fi
   if [ ! -z "$DEPLOYER_BRANCH" ]; then DEPLOYER_BRANCH="-b $DEPLOYER_BRANCH"; fi
+  echo "git clone --depth 1 $DEPLOYER_BRANCH https://github.com/SU-SWS/stanford-jumpstart-deployer.git $HOME/stanford-jumpstart-deployer"
   git clone --depth 1 $DEPLOYER_BRANCH https://github.com/SU-SWS/stanford-jumpstart-deployer.git $HOME/stanford-jumpstart-deployer
   grep -rl 'git@github.com:' $HOME/stanford-jumpstart-deployer | xargs sed -i 's|git@github.com:|https://github.com/|'
   drush make -y --force-complete $HOME/stanford-jumpstart-deployer/production/product/$PRODUCT_NAME/$PRODUCT_NAME.make $HOME/html

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -2,10 +2,7 @@
 
 # install
 export PATH="$HOME/.composer/vendor/bin:$PATH"
-export REPOSITORY_NAME=$(find $TRAVIS_BUILD_URL -mindepth 1 -maxdepth 1 -name "*.info" -type f -printf '%f\n' | cut -f1 -d".")
-if [ -z "$REPOSITORY_NAME"]; then
-  REPOSITORY_NAME="stanford-jumpstart-deployer"
-fi
+export REPOSITORY_NAME=$(basename $TRAVIS_BUILD_DIR)
 sed "s|ACCESS_TOKEN|$ACCESS_TOKEN|" $HOME/stanford_travisci_scripts/.netrc > $HOME/.netrc
 
 # save drush alias and update .htaccess file to allow rewriting
@@ -15,12 +12,18 @@ sed -ie "s|HOME|$HOME|" $HOME/.drush/aliases.drushrc.php
 cat $HOME/.drush/aliases.drushrc.php
 
 if [ -z "$PRODUCT_NAME" ]; then
+  if [ "$REPOSITORY_NAME" == "Stanford-Drupal-Profile" ]; then
+    DRUPAL_PROFILE_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
+  fi
   if [ ! -z "$DRUPAL_PROFILE_BRANCH" ]; then DRUPAL_PROFILE_BRANCH="-b $DRUPAL_PROFILE_BRANCH"; fi
   git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile
   grep -rl 'git@github.com:' $HOME/Stanford-Drupal-Profile | xargs sed -i 's|git@github.com:|https://github.com/|'
   drush make -y --force-complete $HOME/Stanford-Drupal-Profile/make/dept.make $HOME/html
   drush @local si -y stanford --db-url=mysql://root@localhost/drupal --account-name=admin --account-pass=admin
 else
+  if [ "$REPOSITORY_NAME" == "stanford-jumpstart-deployer" ]; then
+    DEPLOYER_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
+  fi
   if [ ! -z "$DEPLOYER_BRANCH" ]; then DEPLOYER_BRANCH="-b $DEPLOYER_BRANCH"; fi
   git clone --depth 1 $DEPLOYER_BRANCH https://github.com/SU-SWS/stanford-jumpstart-deployer.git $HOME/stanford-jumpstart-deployer
   grep -rl 'git@github.com:' $HOME/stanford-jumpstart-deployer | xargs sed -i 's|git@github.com:|https://github.com/|'

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -14,21 +14,37 @@ sed -ie "s|HOME|$HOME|" $HOME/.drush/aliases.drushrc.php
 cat $HOME/.drush/aliases.drushrc.php
 
 function install_from_deployer {
+  # clone deployer and echo which branch will be cloned and used for the site build
   if [ ! -z "$DEPLOYER_BRANCH" ]; then DEPLOYER_BRANCH="-b $DEPLOYER_BRANCH"; fi
   echo "git clone --depth 1 $DEPLOYER_BRANCH https://github.com/SU-SWS/stanford-jumpstart-deployer.git $HOME/stanford-jumpstart-deployer"
   git clone --depth 1 $DEPLOYER_BRANCH https://github.com/SU-SWS/stanford-jumpstart-deployer.git $HOME/stanford-jumpstart-deployer
+
+  # change git clones to https so they can be downloaded with access tokens
   grep -rl 'git@github.com:' $HOME/stanford-jumpstart-deployer | xargs sed -i 's|git@github.com:|https://github.com/|'
+
+  # build site based on specified product name
   drush make -y --force-complete $HOME/stanford-jumpstart-deployer/production/product/$PRODUCT_NAME/$PRODUCT_NAME.make $HOME/html
+
+  # find profile name by looking for "jumpstart" in profiles directory
   export PROFILE_NAME=$(find $HOME/html/profiles -name "*jumpstart*" -type d -printf '%f\n')
+
+  # install site with product profile
   drush @local si -y $PROFILE_NAME --db-url=mysql://root@localhost/drupal --account-name=admin --account-pass=admin
 }
 
 function install_from_drupal_profile {
+  # clone Drupal-Profile and echo which branch will be cloned and used for the site build
   if [ ! -z "$DRUPAL_PROFILE_BRANCH" ]; then DRUPAL_PROFILE_BRANCH="-b $DRUPAL_PROFILE_BRANCH"; fi
   echo "git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile"
   git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile
+
+  # change git clones to https so they can be downloaded with access tokens
   grep -rl 'git@github.com:' $HOME/Stanford-Drupal-Profile | xargs sed -i 's|git@github.com:|https://github.com/|'
+
+  # build self-service site
   drush make -y --force-complete $HOME/Stanford-Drupal-Profile/make/dept.make $HOME/html
+
+  # install site with stanford, ie. self-service, profile
   drush @local si -y stanford --db-url=mysql://root@localhost/drupal --account-name=admin --account-pass=admin
 }
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -3,7 +3,8 @@
 # install
 export PATH="$HOME/.composer/vendor/bin:$PATH"
 export REPOSITORY_NAME=$(basename $TRAVIS_BUILD_DIR)
-echo "$REPOSITORY_NAME"
+
+# save GitHub access token so we can clone from private repositories
 sed "s|ACCESS_TOKEN|$ACCESS_TOKEN|" $HOME/stanford_travisci_scripts/.netrc > $HOME/.netrc
 
 # save drush alias and update .htaccess file to allow rewriting
@@ -12,20 +13,7 @@ cp $HOME/stanford_travisci_scripts/aliases.drushrc.php $HOME/.drush/aliases.drus
 sed -ie "s|HOME|$HOME|" $HOME/.drush/aliases.drushrc.php
 cat $HOME/.drush/aliases.drushrc.php
 
-if [ -z "$PRODUCT_NAME" ]; then
-  if [ "$REPOSITORY_NAME" == "Stanford-Drupal-Profile" ]; then
-    DRUPAL_PROFILE_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
-  fi
-  if [ ! -z "$DRUPAL_PROFILE_BRANCH" ]; then DRUPAL_PROFILE_BRANCH="-b $DRUPAL_PROFILE_BRANCH"; fi
-  echo "git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile"
-  git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile
-  grep -rl 'git@github.com:' $HOME/Stanford-Drupal-Profile | xargs sed -i 's|git@github.com:|https://github.com/|'
-  drush make -y --force-complete $HOME/Stanford-Drupal-Profile/make/dept.make $HOME/html
-  drush @local si -y stanford --db-url=mysql://root@localhost/drupal --account-name=admin --account-pass=admin
-else
-  if [ "$REPOSITORY_NAME" == "stanford-jumpstart-deployer" ]; then
-    DEPLOYER_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
-  fi
+function install_from_deployer {
   if [ ! -z "$DEPLOYER_BRANCH" ]; then DEPLOYER_BRANCH="-b $DEPLOYER_BRANCH"; fi
   echo "git clone --depth 1 $DEPLOYER_BRANCH https://github.com/SU-SWS/stanford-jumpstart-deployer.git $HOME/stanford-jumpstart-deployer"
   git clone --depth 1 $DEPLOYER_BRANCH https://github.com/SU-SWS/stanford-jumpstart-deployer.git $HOME/stanford-jumpstart-deployer
@@ -33,7 +21,33 @@ else
   drush make -y --force-complete $HOME/stanford-jumpstart-deployer/production/product/$PRODUCT_NAME/$PRODUCT_NAME.make $HOME/html
   export PROFILE_NAME=$(find $HOME/html/profiles -name "*jumpstart*" -type d -printf '%f\n')
   drush @local si -y $PROFILE_NAME --db-url=mysql://root@localhost/drupal --account-name=admin --account-pass=admin
+}
+
+function install_from_drupal_profile {
+  if [ ! -z "$DRUPAL_PROFILE_BRANCH" ]; then DRUPAL_PROFILE_BRANCH="-b $DRUPAL_PROFILE_BRANCH"; fi
+  echo "git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile"
+  git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile
+  grep -rl 'git@github.com:' $HOME/Stanford-Drupal-Profile | xargs sed -i 's|git@github.com:|https://github.com/|'
+  drush make -y --force-complete $HOME/Stanford-Drupal-Profile/make/dept.make $HOME/html
+  drush @local si -y stanford --db-url=mysql://root@localhost/drupal --account-name=admin --account-pass=admin
+}
+
+function update_test_branch {
+  # download pull request origination branch when testing profiles
+  if [ "$REPOSITORY_NAME" == "Stanford-Drupal-Profile" ]; then
+    DRUPAL_PROFILE_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
+  elif [ "$REPOSITORY_NAME" == "stanford-jumpstart-deployer" ]; then
+    DEPLOYER_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
+  fi
+}
+
+update_test_branch
+if [ -z "$PRODUCT_NAME" ]; then
+  install_from_drupal_profile
+else
+  install_from_deployer
 fi
+
 # Adjust the rewrite base for the local host.
 sed -ie "s|# RewriteBase /|RewriteBase /|" $HOME/html/.htaccess
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -51,7 +51,7 @@ for MODULE_NAME in $ENABLE_MODULES; do
 done
 
 # Enable modules and submodules if specified.
-if [[ "$REPOSITORY_NAME" != "Stanford-Drupal-Profile" || "$REPOSITORY_NAME" != "stanford-jumpstart-deployer" ]]; then
+if [[ ! "$REPOSITORY_NAME" =~ "Stanford-Drupal-Profile"|"stanford-jumpstart-deployer" ]]; then
   drush @local en -y $REPOSITORY_NAME
 fi
 if [ ! -z "$ENABLE_MODULES" ]; then

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -51,7 +51,9 @@ for MODULE_NAME in $ENABLE_MODULES; do
 done
 
 # Enable modules and submodules if specified.
-drush @local en -y $REPOSITORY_NAME
+if [[ "$REPOSITORY_NAME" != "Stanford-Drupal-Profile" || "$REPOSITORY_NAME" != "stanford-jumpstart-deployer" ]]; then
+  drush @local en -y $REPOSITORY_NAME
+fi
 if [ ! -z "$ENABLE_MODULES" ]; then
   drush @local en -y $ENABLE_MODULES
 fi

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -3,6 +3,7 @@
 # install
 export PATH="$HOME/.composer/vendor/bin:$PATH"
 export REPOSITORY_NAME=$(basename $TRAVIS_BUILD_DIR)
+echo $REPOSITORY_NAME
 sed "s|ACCESS_TOKEN|$ACCESS_TOKEN|" $HOME/stanford_travisci_scripts/.netrc > $HOME/.netrc
 
 # save drush alias and update .htaccess file to allow rewriting

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source includes/install_functions.inc
+
 # install
 export PATH="$HOME/.composer/vendor/bin:$PATH"
 export REPOSITORY_NAME=$(basename $TRAVIS_BUILD_DIR)
@@ -12,50 +14,6 @@ if [ ! -d $HOME/.drush ]; then mkdir $HOME/.drush; fi
 cp $HOME/stanford_travisci_scripts/aliases.drushrc.php $HOME/.drush/aliases.drushrc.php
 sed -ie "s|HOME|$HOME|" $HOME/.drush/aliases.drushrc.php
 cat $HOME/.drush/aliases.drushrc.php
-
-function install_from_deployer {
-  # clone deployer and echo which branch will be cloned and used for the site build
-  if [ ! -z "$DEPLOYER_BRANCH" ]; then DEPLOYER_BRANCH="-b $DEPLOYER_BRANCH"; fi
-  echo "git clone --depth 1 $DEPLOYER_BRANCH https://github.com/SU-SWS/stanford-jumpstart-deployer.git $HOME/stanford-jumpstart-deployer"
-  git clone --depth 1 $DEPLOYER_BRANCH https://github.com/SU-SWS/stanford-jumpstart-deployer.git $HOME/stanford-jumpstart-deployer
-
-  # change git clones to https so they can be downloaded with access tokens
-  grep -rl 'git@github.com:' $HOME/stanford-jumpstart-deployer | xargs sed -i 's|git@github.com:|https://github.com/|'
-
-  # build site based on specified product name
-  drush make -y --force-complete $HOME/stanford-jumpstart-deployer/production/product/$PRODUCT_NAME/$PRODUCT_NAME.make $HOME/html
-
-  # find profile name by looking for "jumpstart" in profiles directory
-  export PROFILE_NAME=$(find $HOME/html/profiles -name "*jumpstart*" -type d -printf '%f\n')
-
-  # install site with product profile
-  drush @local si -y $PROFILE_NAME --db-url=mysql://root@localhost/drupal --account-name=admin --account-pass=admin
-}
-
-function install_from_drupal_profile {
-  # clone Drupal-Profile and echo which branch will be cloned and used for the site build
-  if [ ! -z "$DRUPAL_PROFILE_BRANCH" ]; then DRUPAL_PROFILE_BRANCH="-b $DRUPAL_PROFILE_BRANCH"; fi
-  echo "git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile"
-  git clone --depth 1 $DRUPAL_PROFILE_BRANCH https://github.com/SU-SWS/Stanford-Drupal-Profile.git $HOME/Stanford-Drupal-Profile
-
-  # change git clones to https so they can be downloaded with access tokens
-  grep -rl 'git@github.com:' $HOME/Stanford-Drupal-Profile | xargs sed -i 's|git@github.com:|https://github.com/|'
-
-  # build self-service site
-  drush make -y --force-complete $HOME/Stanford-Drupal-Profile/make/dept.make $HOME/html
-
-  # install site with stanford, ie. self-service, profile
-  drush @local si -y stanford --db-url=mysql://root@localhost/drupal --account-name=admin --account-pass=admin
-}
-
-function update_test_branch {
-  # download pull request origination branch when testing profiles
-  if [ "$REPOSITORY_NAME" == "Stanford-Drupal-Profile" ]; then
-    DRUPAL_PROFILE_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
-  elif [ "$REPOSITORY_NAME" == "stanford-jumpstart-deployer" ]; then
-    DEPLOYER_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
-  fi
-}
 
 update_test_branch
 if [ -z "$PRODUCT_NAME" ]; then

--- a/bin/script.sh
+++ b/bin/script.sh
@@ -16,7 +16,7 @@ echo "Number of failed tests: $FAILURES_COUNT"
 echo "Number of tests counted: $TESTS_COUNT"
 
 # fail script.sh if behat returned at least one failure
-if (( $FAILURES_COUNT > 0 )) || (( $TESTS_COUNT > 0 )); then
+if (( $FAILURES_COUNT > 0 )) || (( $TESTS_COUNT == 0 )); then
   exit 1
 else
   exit 0

--- a/bin/script.sh
+++ b/bin/script.sh
@@ -2,6 +2,7 @@
 
 # script
 export PATH="$HOME/.composer/vendor/bin:$PATH"
+export REPOSITORY_NAME=$(basename $TRAVIS_BUILD_DIR)
 
 # run through all tests in features directory
 cd $HOME/stanford_travisci_scripts
@@ -9,13 +10,13 @@ bin/behat -p default -s dev features
 
 # grap the number of failures from behat's html output summary report
 FAILURES_COUNT=$(cat behat_results/index.html | grep 'scenarios failed of' | sed -r 's/^([^.]+).*$/\1/; s/^[^0-9]*([0-9]+).*$/\1/')
-TESTS_COUNT=$(cat features/*/*.feature | grep -c "Scenario")
+TESTS_COUNT=$(basename `find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature"` | grep -c ".feature")
 
 echo "Number of failed tests: $FAILURES_COUNT"
 echo "Number of tests counted: $TESTS_COUNT"
 
 # fail script.sh if behat returned at least one failure
-if (( $FAILURES_COUNT > 0 )) || (( $TESTS_COUNT == 0 )); then
+if (( $FAILURES_COUNT > 0 )) || (( $TESTS_COUNT > 0 )); then
   exit 1
 else
   exit 0

--- a/bin/script.sh
+++ b/bin/script.sh
@@ -10,13 +10,13 @@ bin/behat -p default -s dev features
 
 # grap the number of failures from behat's html output summary report
 FAILURES_COUNT=$(cat behat_results/index.html | grep 'scenarios failed of' | sed -r 's/^([^.]+).*$/\1/; s/^[^0-9]*([0-9]+).*$/\1/')
-TESTS_COUNT=$(find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature" | grep -c ".feature")
+FEATURE_FILES_COUNT=$(find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature" | grep -c ".feature")
 
 echo "Number of failed tests: $FAILURES_COUNT"
-echo "Number of tests counted: $TESTS_COUNT"
+echo "Number of feature files counted: $TESTS_COUNT"
 
 # fail script.sh if behat returned at least one failure
-if (( $FAILURES_COUNT > 0 )) || (( $TESTS_COUNT == 0 )); then
+if (( $FAILURES_COUNT > 0 )) || (( $FEATURE_FILES_COUNT == 0 )); then
   exit 1
 else
   exit 0

--- a/bin/script.sh
+++ b/bin/script.sh
@@ -10,13 +10,12 @@ bin/behat -p default -s dev features
 
 # grap the number of failures from behat's html output summary report
 FAILURES_COUNT=$(cat behat_results/index.html | grep 'scenarios failed of' | sed -r 's/^([^.]+).*$/\1/; s/^[^0-9]*([0-9]+).*$/\1/')
-FEATURE_FILES_COUNT=$(find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature" | grep -c ".feature")
+FEATURE_FILES=$(find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature")
 
 echo "Number of failed tests: $FAILURES_COUNT"
-echo "Number of feature files counted: $TESTS_COUNT"
 
 # fail script.sh if behat returned at least one failure
-if (( $FAILURES_COUNT > 0 )) || (( $FEATURE_FILES_COUNT == 0 )); then
+if (( $FAILURES_COUNT > 0 )) || [ -z "$FEATURE_FILES" ]; then
   exit 1
 else
   exit 0

--- a/bin/script.sh
+++ b/bin/script.sh
@@ -10,7 +10,7 @@ bin/behat -p default -s dev features
 
 # grap the number of failures from behat's html output summary report
 FAILURES_COUNT=$(cat behat_results/index.html | grep 'scenarios failed of' | sed -r 's/^([^.]+).*$/\1/; s/^[^0-9]*([0-9]+).*$/\1/')
-TESTS_COUNT=$(basename `find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature"` | grep -c ".feature")
+TESTS_COUNT=$(find $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME -type f -name "*.feature" | grep -c ".feature")
 
 echo "Number of failed tests: $FAILURES_COUNT"
 echo "Number of tests counted: $TESTS_COUNT"

--- a/bin/script.sh
+++ b/bin/script.sh
@@ -9,10 +9,12 @@ bin/behat -p default -s dev features
 
 # grap the number of failures from behat's html output summary report
 FAILURES_COUNT=$(cat behat_results/index.html | grep 'scenarios failed of' | sed -r 's/^([^.]+).*$/\1/; s/^[^0-9]*([0-9]+).*$/\1/')
+TESTS_COUNT=$(cat features/*/*.feature | grep -c "Scenario")
+
 echo "Number of failed tests: $FAILURES_COUNT"
 
 # fail script.sh if behat returned at least one failure
-if (( $FAILURES_COUNT > 0 )); then
+if (( $FAILURES_COUNT > 0 )) || (( $TESTS_COUNT == 0 )); then
   exit 1
 else
   exit 0

--- a/bin/script.sh
+++ b/bin/script.sh
@@ -12,6 +12,7 @@ FAILURES_COUNT=$(cat behat_results/index.html | grep 'scenarios failed of' | sed
 TESTS_COUNT=$(cat features/*/*.feature | grep -c "Scenario")
 
 echo "Number of failed tests: $FAILURES_COUNT"
+echo "Number of tests counted: $TESTS_COUNT"
 
 # fail script.sh if behat returned at least one failure
 if (( $FAILURES_COUNT > 0 )) || (( $TESTS_COUNT == 0 )); then


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Extending our TravisCI scripts to accommodate testing on stanford-jumpstart-deployer and Stanford-Drupal-Profile.  Currently, variables like $REPOSITORY_NAME assumed we were testing a Drupal module.

# Needed By (Date)
- This would be useful for the next PR we have to review concerning a module update to our self-service or product profiles. 

# Urgency
- Not super urgency, but the sooner, the more convenient.

# Steps to Test
- Review these builds to see whether there are hidden problems I missed in the build logs.  Some of the problems I tried to fix include:
1. This error message, referring to a lack of space here: https://github.com/SU-SWS/stanford_travisci_scripts/blob/behat-7.x-1.x/bin/install.sh#L6
```
116.48s$ $HOME/stanford_travisci_scripts/bin/install.sh
/home/travis/stanford_travisci_scripts/bin/install.sh: line 6: [: missing `]'
<?php
```
2. That scripts.sh would succeed when no tests were run, because the failure count was not greater than 0.  Now, it should fail when no tests are found in the features directory.  Example: https://travis-ci.org/SU-SWS/Stanford-Drupal-Profile/builds/205129978.

These builds should be based on the latest version of this test-deployer branch:
https://travis-ci.org/SU-SWS/stanford_bean_types/builds/205077405
https://travis-ci.org/SU-SWS/Stanford-Drupal-Profile/builds/205077150
https://travis-ci.org/SU-SWS/stanford-jumpstart-deployer/builds/204750995

# Affected Projects or Products
- Not yet.  It would be nice to have this working before our next client initiated behat sprint, so that we can be sure tests are passing for their products.

# Associated Issues and/or People
@jbickar