### PR TITLE
Stanford branches

### DIFF
--- a/.travis.default.yml
+++ b/.travis.default.yml
@@ -19,9 +19,10 @@
 # Enter as a space separated string, modules and submodules that you
 # would like to enable after the installation profile has run. Useful
 # for adding additional items. You do not need to include the module
-# being tested.
+# being tested. You can include a specific module version or stanford
+# module branch name.
 # Example:
-# stanford_gallery nobots
+# stanford_gallery-7.x-2.x nobots-7.x-1.x-dev stanford_page
 #
 # DISABLE_MODULES:
 # Enter as a space separated string, modules you would like disabled after the

--- a/bin/includes/install_functions.inc
+++ b/bin/includes/install_functions.inc
@@ -45,3 +45,52 @@ function update_test_branch {
     DEPLOYER_BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"
   fi
 }
+
+# Determine if a new module needs to be downloaded
+function remove_old_module_version {
+  if [[ "$CURRENT_MODULE_VERSION" != "$MODULE_BRANCH" ]] && [ ! -z "$CURRENT_MODULE_VERSION" ]; then
+    rm -rf $CURRENT_MODULE_PATH
+  fi
+}
+
+function find_old_module_version {
+  CURRENT_MODULE_PATH=$(find $HOME/html/sites/all/modules -type d -name "$MODULE_NAME")
+  if [ ! -z "$CURRENT_MODULE_PATH" ]; then
+    CURRENT_MODULE_VERSION=$(drush @local pmi --format=list --fields=version --field-labels=0 $MODULE_NAME)
+    echo "module version: $CURRENT_MODULE_VERSION"
+    remove_old_module_version
+  fi
+}
+
+# Find modules with specified versions
+function check_for_module_version {
+  if [[ "$MODULE" == *"-"* ]]; then
+    MODULE_NAME=$(echo $MODULE | cut -d "-" -f 1)
+    MODULE_BRANCH=$(echo $MODULE | cut -d "-" -f 2-)
+    echo "module name: $MODULE_NAME module branch: $MODULE_BRANCH"
+    find_old_module_version
+  else
+    MODULE_NAME=$MODULE
+    MODULE_BRANCH=""
+  fi
+}
+
+function download_stanford_module {
+  EXISTS=$(curl -X HEAD -I https://github.com/SU-SWS/$MODULE_NAME 2>/dev/null | head -n 1);
+  if [[ $EXISTS =~ .*200\ OK.* ]]; then
+    if [ ! -z "$MODULE_BRANCH" ] && [ -z "$MODULE_PATH" ]; then MODULE_BRANCH="-b $MODULE_BRANCH"; fi
+    echo "git clone $MODULE_BRANCH https://github.com/SU-SWS/$MODULE_NAME.git $HOME/html/sites/all/modules/stanford/$MODULE_NAME"
+    git clone $MODULE_BRANCH https://github.com/SU-SWS/$MODULE_NAME.git $HOME/html/sites/all/modules/stanford/$MODULE_NAME
+  fi
+}
+
+function install_new_module_version {
+  # module directory should not be there if updating the module version
+  if [[ "$MODULE_NAME" == "stanford"* ]] && [ ! -d $HOME/html/sites/all/modules/stanford/$MODULE_NAME ]; then
+    download_stanford_module
+  else
+    drush @local dl -y $MODULE
+  fi
+  drush @local en -y $MODULE_NAME
+}
+

--- a/bin/includes/install_functions.inc
+++ b/bin/includes/install_functions.inc
@@ -71,7 +71,6 @@ function check_for_module_version {
     find_old_module_version
   else
     MODULE_NAME=$MODULE
-    MODULE_BRANCH=""
   fi
 }
 

--- a/bin/includes/install_functions.inc
+++ b/bin/includes/install_functions.inc
@@ -46,15 +46,15 @@ function update_test_branch {
   fi
 }
 
-# Determine if a new module needs to be downloaded
+# remove if the module version on the build site does not match the specified version
 function remove_old_module_version {
   if [[ "$CURRENT_MODULE_VERSION" != "$MODULE_BRANCH" ]] && [ ! -z "$CURRENT_MODULE_VERSION" ]; then
     rm -rf $CURRENT_MODULE_PATH
   fi
 }
 
+# find the existing module version installed on the build site
 function find_old_module_version {
-  CURRENT_MODULE_PATH=$(find $HOME/html/sites/all/modules -type d -name "$MODULE_NAME")
   if [ ! -z "$CURRENT_MODULE_PATH" ]; then
     CURRENT_MODULE_VERSION=$(drush @local pmi --format=list --fields=version --field-labels=0 $MODULE_NAME)
     echo "module version: $CURRENT_MODULE_VERSION"
@@ -62,7 +62,7 @@ function find_old_module_version {
   fi
 }
 
-# Find modules with specified versions
+# parse enabled modules string to see if a module version has been specified
 function check_for_module_version {
   if [[ "$MODULE" == *"-"* ]]; then
     MODULE_NAME=$(echo $MODULE | cut -d "-" -f 1)
@@ -75,22 +75,29 @@ function check_for_module_version {
   fi
 }
 
-function download_stanford_module {
-  EXISTS=$(curl -X HEAD -I https://github.com/SU-SWS/$MODULE_NAME 2>/dev/null | head -n 1);
-  if [[ $EXISTS =~ .*200\ OK.* ]]; then
-    if [ ! -z "$MODULE_BRANCH" ] && [ -z "$MODULE_PATH" ]; then MODULE_BRANCH="-b $MODULE_BRANCH"; fi
-    echo "git clone $MODULE_BRANCH https://github.com/SU-SWS/$MODULE_NAME.git $HOME/html/sites/all/modules/stanford/$MODULE_NAME"
-    git clone $MODULE_BRANCH https://github.com/SU-SWS/$MODULE_NAME.git $HOME/html/sites/all/modules/stanford/$MODULE_NAME
-  fi
-}
-
-function install_new_module_version {
-  # module directory should not be there if updating the module version
-  if [[ "$MODULE_NAME" == "stanford"* ]] && [ ! -d $HOME/html/sites/all/modules/stanford/$MODULE_NAME ]; then
-    download_stanford_module
+# downloading should not be overwriting any existing modules
+# either the previous module version has been removed
+# or this step is being skipped because the module version on the
+# build site has been found acceptable.
+function download_new_module {
+  if [[ "$MODULE_NAME" == "stanford"* ]]; then
+    EXISTS=$(curl -X HEAD -I https://github.com/SU-SWS/$MODULE_NAME 2>/dev/null | head -n 1);
+    if [[ $EXISTS =~ .*200\ OK.* ]]; then
+      if [ ! -z "$MODULE_BRANCH" ] && [ -z "$MODULE_PATH" ]; then MODULE_BRANCH="-b $MODULE_BRANCH"; fi
+      echo "git clone $MODULE_BRANCH https://github.com/SU-SWS/$MODULE_NAME.git $HOME/html/sites/all/modules/stanford/$MODULE_NAME"
+      git clone $MODULE_BRANCH https://github.com/SU-SWS/$MODULE_NAME.git $HOME/html/sites/all/modules/stanford/$MODULE_NAME
+    fi
   else
     drush @local dl -y $MODULE
   fi
-  drush @local en -y $MODULE_NAME
 }
 
+# check whether the module needs to be downloaded, then enable
+function install_new_module_version {
+  # module directory should not be there if updating the module version
+  CURRENT_MODULE_PATH=$(find $HOME/html/sites/all/modules -type d -name "$MODULE_NAME")
+  if [ -z "$CURRENT_MODULE_PATH" ]; then
+    download_new_module
+  fi
+  drush @local en -y $MODULE_NAME
+}

--- a/bin/includes/script_functions.inc
+++ b/bin/includes/script_functions.inc
@@ -36,6 +36,8 @@ function copy_assets {
     find $HOME/linky_clicky -type f -name "$EXTENSION"
     find $HOME/linky_clicky -type f -name "$EXTENSION" -exec cp {} $HOME/stanford_travisci_scripts/img/ \;
   done
+  # find not locating filefield_path.txt file
+  cp $HOME/linky_clicky/sites/uat/img/filefield_path.txt $HOME/stanford_travisci_scripts/img/
 }
 
 # loop through and copy specific tests called for by ONLY_TEST variable

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -47,6 +47,11 @@ fi
 # Download and enable specified module and module versions
 if [ ! -z "$ENABLE_MODULES" ]; then
   for MODULE in $ENABLE_MODULES; do
+    # clear out variable values from previous module
+    MODULE_NAME=""
+    BRANCH_NAME=""
+    CURRENT_MODULE_PATH=""
+    CURRENT_MODULE_VERSION=""
     echo $MODULE
     check_for_module_version
     install_new_module_version

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -44,53 +44,6 @@ if [ ! -z "$DISABLE_MODULES" ]; then
   drush @local dis -y "$DISABLE_MODULES"
 fi
 
-# Determine if a new module needs to be downloaded
-function remove_old_module_version {
-  if [[ "$CURRENT_MODULE_VERSION" != "$MODULE_BRANCH" ]] && [ ! -z "$CURRENT_MODULE_VERSION" ]; then
-    rm -rf $CURRENT_MODULE_PATH
-  fi
-}
-
-function find_old_module_version {
-  CURRENT_MODULE_PATH=$(find $HOME/html/sites/all/modules -type d -name "$MODULE_NAME")
-  if [ ! -z "$CURRENT_MODULE_PATH" ]; then
-    CURRENT_MODULE_VERSION=$(drush @local pmi --format=list --fields=version --field-labels=0 $MODULE_NAME)
-    echo "module version: $CURRENT_MODULE_VERSION"
-    remove_old_module_version
-  fi
-}
-
-# Find modules with specified versions
-function check_for_module_version {
-  if [[ "$MODULE" == *"-"* ]]; then
-    MODULE_NAME=$(echo $MODULE | cut -d "-" -f 1)
-    MODULE_BRANCH=$(echo $MODULE | cut -d "-" -f 2-)
-    echo "module name: $MODULE_NAME module branch: $MODULE_BRANCH"
-    find_old_module_version
-  else
-    MODULE_NAME=$MODULE
-    MODULE_BRANCH=""
-  fi
-}
-
-function download_stanford_module {
-  EXISTS=$(curl -X HEAD -I https://github.com/SU-SWS/$MODULE_NAME 2>/dev/null | head -n 1);
-  if [[ $EXISTS =~ .*200\ OK.* ]]; then
-    if [ ! -z "$MODULE_BRANCH" ] && [ -z "$MODULE_PATH" ]; then MODULE_BRANCH="-b $MODULE_BRANCH"; fi
-    echo "git clone $MODULE_BRANCH https://github.com/SU-SWS/$MODULE_NAME.git $HOME/html/sites/all/modules/stanford/$MODULE_NAME"
-    git clone $MODULE_BRANCH https://github.com/SU-SWS/$MODULE_NAME.git $HOME/html/sites/all/modules/stanford/$MODULE_NAME
-  fi
-}
-
-function install_new_module_version {
-  if [[ "$MODULE_NAME" == "stanford"* ]]; then
-    download_stanford_module
-  else
-    drush @local dl -y $MODULE
-  fi
-  drush @local en -y $MODULE_NAME
-}
-
 if [ ! -z "$ENABLE_MODULES" ]; then
   for MODULE in $ENABLE_MODULES; do
     echo $MODULE

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -44,6 +44,7 @@ if [ ! -z "$DISABLE_MODULES" ]; then
   drush @local dis -y "$DISABLE_MODULES"
 fi
 
+# Download and enable specified module and module versions
 if [ ! -z "$ENABLE_MODULES" ]; then
   for MODULE in $ENABLE_MODULES; do
     echo $MODULE


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- @pookmish requested that we be able to specify the module version we want (downloaded) and enabled on a build site, without having to create a Stanford-Drupal-Profile branch just for this purpose.  Shea seconded, saying this will be an increasingly useful feature as we build more Drupal 8 versions of our modules.  We can't assume the default will be useful for our test.

# Needed By (Date)
- It sounds like Mike has some modules he is currently testing, which could make use of this feature.

# Steps to Test
- Mike, you can specify in the .travis.yml file of your repository that you want to use "stanford-branches" for the SCRIPTS_BRANCH variable.  And then enter the modules with their required versions for ENABLE_MODULES.  Let me know how it goes.

Output from running locally with the enabled modules string, "stanford_gallery-7.x-2.x nobots-7.x-1.x-dev stanford_page"
```
Do you really want to continue? (y/n): y
webauth was disabled successfully.                                                                                                                                                                [ok]
stanford_gallery-7.x-2.x
module name: stanford_gallery module branch: 7.x-2.x
Colorbox plugin has been installed in sites/all/libraries                                                                                                                                         [success]
The following extensions will be enabled: stanford_gallery, stanford_image_styles, stanford_image, field_group, field_collection, ds, colorbox
Do you really want to continue? (y/n): y
colorbox was enabled successfully.                                                                                                                                                                [ok]
field_collection was enabled successfully.                                                                                                                                                        [ok]
field_collection defines the following permissions: administer field collections
stanford_gallery was enabled successfully.                                                                                                                                                        [ok]
stanford_image was enabled successfully.                                                                                                                                                          [ok]
stanford_image_styles was enabled successfully.                                                                                                                                                   [ok]
ds was enabled successfully.                                                                                                                                                                      [ok]
ds defines the following permissions: admin_display_suite
field_group was enabled successfully.                                                                                                                                                             [ok]
field_group defines the following permissions: administer fieldgroups
stanford_page
The following extensions will be enabled: stanford_page
Do you really want to continue? (y/n): y
stanford_page was enabled successfully.                                                                                                                                                           [ok]
nobots-7.x-1.x-dev
module name: nobots module branch: 7.x-1.x-dev
The following extensions will be enabled: nobots
Do you really want to continue? (y/n): y
nobots was enabled successfully.                                                                                                                                                                  [ok]
features is already enabled.                                                                                                                                                                      [ok]
There were no extensions that could be enabled.                                                                                                                                                   [ok]
The following modules will be reverted: stanford_image, stanford_page
Do you really want to continue? (y/n): y
Reverted stanford_image.views_view.                                                                                                                                                               [ok]
Reverted stanford_page.views_view.
```

# Associated Issues and/or People
- @sherakama 