### PR TITLE
Copy symlinked files

### DIFF
--- a/bin/includes/script_functions.inc
+++ b/bin/includes/script_functions.inc
@@ -13,19 +13,19 @@ function copy_product_tests {
   ACRONYM="${PRODUCTS_LIST[$PRODUCT_NAME]}"
   if [ ! -z "$ACRONYM" ]; then
     echo "cp -r $HOME/linky_clicky/products/$ACRONYM/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME"
-    cp -r $HOME/linky_clicky/products/$ACRONYM/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
+    cp -rL $HOME/linky_clicky/products/$ACRONYM/features $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
   fi
 }
 
 function copy_uat_tests {
-  cp -r $HOME/linky_clicky/sites/uat/features/high-value $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
+  cp -rL $HOME/linky_clicky/sites/uat/features/high-value $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME
   # remove mollom and capx features, so long as they remain unencrypted
   rm $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME/mollom.feature
   rm $HOME/stanford_travisci_scripts/features/$REPOSITORY_NAME/stanford_capx.feature
 }
 
 function copy_module_tests {
-  cp -r $HOME/linky_clicky/includes/features/SU-SWS/$REPOSITORY_NAME $HOME/stanford_travisci_scripts/features/.
+  cp -rL $HOME/linky_clicky/includes/features/SU-SWS/$REPOSITORY_NAME $HOME/stanford_travisci_scripts/features/.
 }
 
 # find and copy assets when running uat tests


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Mike noticed that when copying files from linky_clicky these scripts did not copy the content of symlinked directories.  I chose to add the -L option, which copies the symlinked directories/files, and not the symlink itself because the original symlinks used relative paths, which I did not want to try and re-create.  

# Urgency
- It sounds like Mike is blocked from testing an update to the stanford_capx tests (which is not yet part of the 5.x JSA product test suite: https://github.com/SU-SWS/linky_clicky/tree/5.x/products/jsa/features).

# Steps to Test

Test: https://github.com/SU-SWS/stanford-jumpstart-deployer/pull/136
Result: https://travis-ci.org/SU-SWS/stanford-jumpstart-deployer/jobs/219854181#L876-L941