### PR TITLE
Add color back to behat results output

### DIFF
--- a/bin/script.sh
+++ b/bin/script.sh
@@ -13,7 +13,7 @@ else
   TAGS="@$BEHAT_TAG&&~@sites&&~@webauth&&~@email"
 fi
 
-bin/behat -p default -s dev --tags "$TAGS" features
+bin/behat -p default -s dev --tags "$TAGS" --colors features
 
 
 # grap the number of failures from behat's html output summary report


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updates to the Travis container image used to test our products stripped the color from behat test results.  This flag should add it back.

# Steps to Test

1. Commit as your SCRIPTS_BRANCH value, "behat-color" and commit, ie. here: https://github.com/SU-SWS/stanford_paragraph_types/blob/HSDO-939-section-header/.travis.yml#L74.
2. Be sure the Travis output shows behat tests results in color.
