### PR TITLE
Run behat tests with chrome and chromedriver 2.35

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -9,6 +9,7 @@ imports:
 default:
   extensions:
     Behat\MinkExtension:
+      javascript_session: selenium2
       goutte:
         guzzle_parameters:
           verify: false

--- a/behat.yml
+++ b/behat.yml
@@ -23,8 +23,6 @@ default:
       base_url: http://127.0.0.1:8080
     Drupal\DrupalExtension:
       api_driver: 'drush'
-      drupal:
-        drupal_root: /home/travis/html
       drush:
         alias: 'local'
     emuse\BehatHTMLFormatter\BehatHTMLFormatterExtension:

--- a/behat.yml
+++ b/behat.yml
@@ -21,7 +21,6 @@ default:
                 switches:
                   - "--headless"
       base_url: http://127.0.0.1:8080
-      files_path: "."
     Drupal\DrupalExtension:
       api_driver: 'drush'
       drupal:

--- a/behat.yml
+++ b/behat.yml
@@ -12,16 +12,17 @@ default:
       goutte:
         guzzle_parameters:
           verify: false
-      sessions:
-        default:
-          selenium2:
-            browser: chrome
-            capabilities:
-              chrome:
-                switches:
-                  - "--headless"
+      javascript_session: selenium2
+      selenium2:
+        browser: chrome
+        capabilities:
+          chrome:
+            switches:
+              - "--headless"
       base_url: http://127.0.0.1:8080
+      files_path: "."
     Drupal\DrupalExtension:
+      blackbox: ~
       api_driver: 'drush'
       drush:
         alias: 'local'

--- a/behat.yml
+++ b/behat.yml
@@ -9,15 +9,22 @@ imports:
 default:
   extensions:
     Behat\MinkExtension:
+      base_url: http://127.0.0.1:8080
+      browser_name: googlechrome
+      javascript_session: selenium2
+      sessions:
+        default:
+          selenium2:
+            wd_host: http://127.0.0.1:4444/wd/hub
+            browser: chrome
+            capabilities:
+              chrome:
+                switches:
+                  - "--headless"
+                  - "--disable-gpu"
       goutte:
         guzzle_parameters:
           verify: false
-      javascript_session: selenium2
-      browser_name: firefox
-      selenium2:
-        browser: firefox
-      base_url: http://127.0.0.1:8080
-      files_path: "."
     Drupal\DrupalExtension:
       blackbox: ~
       api_driver: 'drush'

--- a/behat.yml
+++ b/behat.yml
@@ -15,10 +15,6 @@ default:
       javascript_session: selenium2
       selenium2:
         browser: chrome
-        capabilities:
-          chrome:
-            switches:
-              - "--headless"
       base_url: http://127.0.0.1:8080
       files_path: "."
     Drupal\DrupalExtension:

--- a/behat.yml
+++ b/behat.yml
@@ -9,7 +9,6 @@ imports:
 default:
   extensions:
     Behat\MinkExtension:
-      javascript_session: selenium2
       goutte:
         guzzle_parameters:
           verify: false
@@ -21,17 +20,14 @@ default:
               chrome:
                 switches:
                   - "--headless"
-                  - "--disable-gpu"
       base_url: http://127.0.0.1:8080
       files_path: "."
     Drupal\DrupalExtension:
-      blackbox: ~
       api_driver: 'drush'
+      drupal:
+        drupal_root: /home/travis/html
       drush:
         alias: 'local'
-    Lakion\Behat\MinkDebugExtension:
-      directory: /home/travis/lakion
-      screenshot: true
     emuse\BehatHTMLFormatter\BehatHTMLFormatterExtension:
       name: html
       renderer: Twig,Behat2

--- a/behat.yml
+++ b/behat.yml
@@ -10,10 +10,15 @@ default:
   extensions:
     Behat\MinkExtension:
       goutte: ~
-      javascript_session: selenium2
-      browser_name: firefox
+      default_session: selenium2
       selenium2:
-        browser: firefox
+        browser: chrome
+        wd_host: http://127.0.0.1:4444/wd/hub
+        capabilities:
+          chrome:
+            switches:
+              - "--headless"
+              - "--disable-gpu"
       base_url: http://127.0.0.1:8080
       files_path: "."
     Drupal\DrupalExtension:

--- a/behat.yml
+++ b/behat.yml
@@ -9,16 +9,18 @@ imports:
 default:
   extensions:
     Behat\MinkExtension:
-      goutte: ~
-      default_session: selenium2
-      selenium2:
-        browser: chrome
-        wd_host: http://127.0.0.1:4444/wd/hub
-        capabilities:
-          chrome:
-            switches:
-              - "--headless"
-              - "--disable-gpu"
+      goutte:
+        guzzle_parameters:
+          verify: false
+      sessions:
+        default:
+          selenium2:
+            browser: chrome
+            capabilities:
+              chrome:
+                switches:
+                  - "--headless"
+                  - "--disable-gpu"
       base_url: http://127.0.0.1:8080
       files_path: "."
     Drupal\DrupalExtension:

--- a/behat.yml
+++ b/behat.yml
@@ -13,8 +13,9 @@ default:
         guzzle_parameters:
           verify: false
       javascript_session: selenium2
+      browser_name: firefox
       selenium2:
-        browser: chrome
+        browser: firefox
       base_url: http://127.0.0.1:8080
       files_path: "."
     Drupal\DrupalExtension:

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -15,7 +15,7 @@ mkdir $HOME/stanford_travisci_scripts/includes/extensions
 cp $HOME/linky_clicky/includes/bootstrap/* $HOME/stanford_travisci_scripts/features/bootstrap/.
 cp $HOME/linky_clicky/includes/config/default.yml $HOME/stanford_travisci_scripts/includes/config/.
 cp $HOME/linky_clicky/includes/extensions/drupal.extension.yml $HOME/stanford_travisci_scripts/includes/extensions/.
-cp $HOME/linky_clicky/includes/extensions/mink.extension.yml $HOME/stanford_travisci_scripts/includes/extensions/.
+cp $HOME/stanford_travis_scripts/mink.extension.yml $HOME/stanford_travisci_scripts/includes/extensions/.
 
 # determine which tests to copy based on type of repository or ONLY_TEST variable
 copy_assets

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -15,7 +15,7 @@ mkdir $HOME/stanford_travisci_scripts/includes/extensions
 cp $HOME/linky_clicky/includes/bootstrap/* $HOME/stanford_travisci_scripts/features/bootstrap/.
 cp $HOME/linky_clicky/includes/config/default.yml $HOME/stanford_travisci_scripts/includes/config/.
 cp $HOME/linky_clicky/includes/extensions/drupal.extension.yml $HOME/stanford_travisci_scripts/includes/extensions/.
-cp $HOME/stanford_travis_scripts/mink.extension.yml $HOME/stanford_travisci_scripts/includes/extensions/.
+cp $HOME/stanford_travisci_scripts/mink.extension.yml $HOME/stanford_travisci_scripts/includes/extensions/.
 
 # determine which tests to copy based on type of repository or ONLY_TEST variable
 copy_assets

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -76,7 +76,7 @@ sudo apt-get -f install -y
 google-chrome --version
 
 status "Installing Chromedriver"
-wget https://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip
+wget https://chromedriver.storage.googleapis.com/2.35/chromedriver_linux64.zip
 unzip chromedriver_linux64.zip
 sudo mv -f chromedriver /usr/local/share/chromedriver
 sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -65,6 +65,23 @@ php -S 127.0.0.1:8080 $HOME/html/routing.php &>/dev/null &
 until netstat -an 2>/dev/null | grep '8080.*LISTEN'; do true; done
 cd ..
 
+# download and install Chrome
+sudo apt-get install libxss1 libappindicator1 libindicator7 vim wget -y
+wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+
+# Unpackaging chrome returns an error because it is missing dependencies, which is not a problem,
+# We install them a moment later.  So adding || true to be sure this behavior does not quite the script.
+sudo dpkg -i google-chrome-stable_current_amd64.deb || true
+sudo apt-get -f install -y
+google-chrome --version
+
+status "Installing Chromedriver"
+wget https://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip
+unzip chromedriver_linux64.zip
+sudo mv -f chromedriver /usr/local/share/chromedriver
+sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
+sudo ln -s /usr/local/share/chromedriver /usr/bin/chromedriver
+
 # download recommended version of selenium-server, start, silence, and background process
 wget http://selenium-release.storage.googleapis.com/2.47/selenium-server-standalone-2.47.1.jar
 java -jar selenium-server-standalone-2.47.1.jar -p 4444 &>/dev/null &

--- a/bin/before_script.sh
+++ b/bin/before_script.sh
@@ -70,7 +70,7 @@ sudo apt-get install libxss1 libappindicator1 libindicator7 vim wget -y
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 
 # Unpackaging chrome returns an error because it is missing dependencies, which is not a problem,
-# We install them a moment later.  So adding || true to be sure this behavior does not quite the script.
+# We install them a moment later.  So adding || true to be sure this behavior does not quit the script.
 sudo dpkg -i google-chrome-stable_current_amd64.deb || true
 sudo apt-get -f install -y
 google-chrome --version

--- a/bin/script.sh
+++ b/bin/script.sh
@@ -13,8 +13,11 @@ else
   TAGS="@$BEHAT_TAG&&~@sites&&~@webauth&&~@email"
 fi
 
-bin/behat -p default -s dev --tags "$TAGS" --colors features -v
+pwd
+ls features
+ls features/Stanford-Drupal-Profile
 
+bin/behat -p default -s dev --tags "$TAGS" --colors features -v
 
 # grap the number of failures from behat's html output summary report
 FAILURES_COUNT=$(cat behat_results/index.html | grep 'scenarios failed of' | sed -r 's/^([^.]+).*$/\1/; s/^[^0-9]*([0-9]+).*$/\1/')

--- a/bin/script.sh
+++ b/bin/script.sh
@@ -13,10 +13,6 @@ else
   TAGS="@$BEHAT_TAG&&~@sites&&~@webauth&&~@email"
 fi
 
-pwd
-ls features
-ls features/Stanford-Drupal-Profile
-
 bin/behat -p default -s dev --tags "$TAGS" --colors features -v
 
 # grap the number of failures from behat's html output summary report

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "behat/mink": "^1.7.0",
     "behat/mink-selenium2-driver": "^1.3.1",
     "behat/mink-goutte-driver": "^1.2.1",
-    "drupal/drupal-extension": "~3.0",
+    "drupal/drupal-extension": "~3.3.1",
     "weavora/mink-extra-context": "dev-master",
     "drupal/drupal-driver": "^1.2.1",
     "drush/drush": "8.1.10",

--- a/mink.extension.yml
+++ b/mink.extension.yml
@@ -1,0 +1,10 @@
+default:
+  extensions:
+    Behat\MinkExtension:
+      goutte: ~
+      javascript_session: selenium2
+      browser_name: googlechrome
+      selenium2:
+         browser: chrome
+      base_url: http://sites.stanford.edu/example
+      files_path: "."


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- We have been experiencing several issues with our travis scripts lately, most pressing: javascript tests have been failing with firefox and chrome.  Updating chromedriver to 2.35, release 1/10/2018 appears to solve that problem.  This work also includes updates to drupal-extension.

(This does not fix an update to the imgur api which means screenshots are no longer uploaded and linked for failed tests.)

# Needed By (Tues.)
- No particular date, but this has been a pain point for development.

# Urgency
- See above.

# Steps to Test

1. I tested this against stanford_courses, let's try another module, with tests that we know should pass.  You can test it by updating the .travis.yml file in a repository, so that $SCRIPTS_BRANCH="test-chrome-update".
2. Wait quite a while.
3. See if you get past any javascript tests.

# Delete the following branches and close the following PR's after merging this work:
https://github.com/SU-SWS/stanford_courses/pull/79
https://github.com/SU-SWS/stanford_bean_types/pull/70
https://github.com/SU-SWS/Stanford-Drupal-Profile/pull/96

# Affected Projects or Products
- It has affected quite a few different projects.  Let me know if you want me to dig up the list of which.